### PR TITLE
update discord url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/verygoodgraphics
     - icon: fontawesome/brands/discord
-      link: https://discord.gg/g3HJuKP54D
+      link: https://discord.gg/vB3bcSvNvb
     # - icon: fontawesome/solid/envelope
     #   link: mailto:<bd@verygoodgraphics.com>
 


### PR DESCRIPTION
Discord url in VGG Docs should refer to vgg channel.